### PR TITLE
Fix copper armour being the default texture

### DIFF
--- a/src/main/java/com/redlimerl/detailab/api/render/CustomArmorBar.java
+++ b/src/main/java/com/redlimerl/detailab/api/render/CustomArmorBar.java
@@ -10,7 +10,7 @@ import java.util.function.Function;
 public class CustomArmorBar {
 
     public static CustomArmorBar DEFAULT = new CustomArmorBar(itemStack -> new ArmorBarRenderManager(DetailArmorBar.GUI_ARMOR_BAR, 146, 128,
-            new TextureOffset(63, 9 + DetailArmorBar.isVanillaTexture()), new TextureOffset(54, 9 + DetailArmorBar.isVanillaTexture()),
+            new TextureOffset(81, 9 + DetailArmorBar.isVanillaTexture()), new TextureOffset(72, 9 + DetailArmorBar.isVanillaTexture()),
             new TextureOffset(9, 0), new TextureOffset(27, 0)));
 
     public static CustomArmorBar EMPTY = new CustomArmorBar(itemStack -> {
@@ -18,8 +18,7 @@ public class CustomArmorBar {
             return new ArmorBarRenderManager(DetailArmorBar.GUI_ARMOR_BAR, 146, 128,
                     new TextureOffset(45, 0), new TextureOffset(45, 0), new TextureOffset(9, 0), new TextureOffset(27, 0));
         } else {
-            return new ArmorBarRenderManager(
-                    DetailArmorBar.GUI_ARMOR_BAR, 146, 128,
+            return new ArmorBarRenderManager(DetailArmorBar.GUI_ARMOR_BAR, 146, 128,
                     new TextureOffset(0, 0), new TextureOffset(0, 0), new TextureOffset(0, 0), new TextureOffset(0, 0));
         }
     });


### PR DESCRIPTION
Hey again!
#7 forgot to change the `DEFAULT` armour visual, making copper into the default appearance for unknown sources, attributes, or when the "Armor Type Bar" option is off.
Here's the fix.

Before:
<img width="856" height="136" alt="image" src="https://github.com/user-attachments/assets/61e81f2f-cad2-43d0-9f7a-107f5b9e17cc" />
After:
<img width="855" height="135" alt="image" src="https://github.com/user-attachments/assets/3d4f6a8a-cf99-4130-99da-825a40534fcd" />
