### PR TITLE
Fix glints

### DIFF
--- a/example_resourcepack/assets/detailab/armor_bar/diamond.json
+++ b/example_resourcepack/assets/detailab/armor_bar/diamond.json
@@ -9,13 +9,13 @@
   "render": {
     "full": {
       "texture": "detailab:textures/armor_bar.png",
-      "texture_width": 128,
+      "texture_width": 146,
       "texture_height": 128,
       "offset": [ 27, 9 ]
     },
     "half": {
       "texture": "detailab:textures/armor_bar.png",
-      "texture_width": 128,
+      "texture_width": 146,
       "texture_height": 128,
       "offset": [ 18, 9 ]
     }

--- a/example_resourcepack/assets/detailab/armor_bar/elytra.json
+++ b/example_resourcepack/assets/detailab/armor_bar/elytra.json
@@ -4,13 +4,13 @@
   "render": {
     "main": {
       "texture": "detailab:textures/armor_bar.png",
-      "texture_width": 128,
+      "texture_width": 146,
       "texture_height": 128,
       "offset": [36, 0]
     },
     "outline": {
       "texture": "detailab:textures/armor_bar.png",
-      "texture_width": 128,
+      "texture_width": 146,
       "texture_height": 128,
       "offset": [54, 0]
     },

--- a/src/main/java/com/redlimerl/detailab/render/InGameDrawer.java
+++ b/src/main/java/com/redlimerl/detailab/render/InGameDrawer.java
@@ -11,7 +11,7 @@ import java.awt.*;
 @SuppressWarnings({"SuspiciousNameCombination", "SameParameterValue"})
 public class InGameDrawer {
     public static void drawTexture(Identifier identifier, DrawContext context, int x, int y, int u, int v, Color color, boolean mirror) {
-        drawTexture(identifier, context, x, y, u, v, 128, 128, color, mirror);
+        drawTexture(identifier, context, x, y, u, v, 146, 128, color, mirror);
     }
 
     public static void drawTexture(Identifier identifier, DrawContext context, int x, int y, int u, int v, int width, int height, Color color, boolean mirror) {


### PR DESCRIPTION
Updating the `armor_bar.png` texture in #7 had one other unintended effect: the glints broke.
<img width="105" height="87" alt="image" src="https://github.com/user-attachments/assets/bc5c03b7-7189-4239-97d0-4d6d43a7c460" />

Just a result of not changing the texture dimensions in one more place.
<img width="77" height="71" alt="image" src="https://github.com/user-attachments/assets/96021d98-3aa5-453a-a0ab-ae2126b3ae93" />
